### PR TITLE
Handles unexpected responses from KeyAuth addCredentials method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.vaibhav-sinha</groupId>
     <artifactId>kong-java-client</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/github/vaibhavsinha/kong/exception/KongClientException.java
+++ b/src/main/java/com/github/vaibhavsinha/kong/exception/KongClientException.java
@@ -2,10 +2,30 @@ package com.github.vaibhavsinha.kong.exception;
 
 /**
  * Created by vaibhav on 13/06/17.
+ *
+ * Updated by dvilela on 11/08/17.
  */
 public class KongClientException extends RuntimeException {
 
+    private int code;
+
+    private String error;
+
     public KongClientException(String message) {
         super(message);
+    }
+
+    public KongClientException(String message, int code, String error) {
+        super(message);
+        this.code = code;
+        this.error = error;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getError() {
+        return error;
     }
 }

--- a/src/main/java/com/github/vaibhavsinha/kong/impl/service/plugin/authentication/KeyAuthServiceImpl.java
+++ b/src/main/java/com/github/vaibhavsinha/kong/impl/service/plugin/authentication/KeyAuthServiceImpl.java
@@ -5,6 +5,7 @@ import com.github.vaibhavsinha.kong.exception.KongClientException;
 import com.github.vaibhavsinha.kong.internal.plugin.authentication.RetrofitKeyAuthService;
 import com.github.vaibhavsinha.kong.model.plugin.authentication.key.KeyAuthCredential;
 import com.github.vaibhavsinha.kong.model.plugin.authentication.key.KeyAuthCredentialList;
+import retrofit2.Response;
 
 import java.io.IOException;
 
@@ -26,8 +27,12 @@ public class KeyAuthServiceImpl implements KeyAuthService {
     @Override
     public KeyAuthCredential addCredentials(String consumerIdOrUsername, String key) {
         try {
-            return retrofitKeyAuthService.addCredentials(consumerIdOrUsername, new KeyAuthCredential(key)).execute()
-                    .body();
+            Response<KeyAuthCredential> res = retrofitKeyAuthService.addCredentials(consumerIdOrUsername,
+                    new KeyAuthCredential(key)).execute();
+            if (res.code() == 201) {
+                return res.body();
+            }
+            throw new KongClientException("Could not create credentials", res.code(), res.message());
         } catch (IOException e) {
             throw new KongClientException(e.getMessage());
         }

--- a/src/test/java/com/github/vaibhavsinha/kong/RetrofitJwtServiceTest.java
+++ b/src/test/java/com/github/vaibhavsinha/kong/RetrofitJwtServiceTest.java
@@ -3,8 +3,8 @@ package com.github.vaibhavsinha.kong;
 import com.github.vaibhavsinha.kong.model.admin.consumer.Consumer;
 import com.github.vaibhavsinha.kong.model.plugin.authentication.jwt.JwtCredential;
 import com.github.vaibhavsinha.kong.model.plugin.authentication.jwt.JwtCredentialList;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -21,33 +21,30 @@ public class RetrofitJwtServiceTest extends BaseTest {
 
     private static Consumer consumer;
 
-    @BeforeClass
-    public static void createConsumer() throws Exception {
+    @Before
+    public void createConsumerAndAddCredential() throws Exception {
         Consumer c = new Consumer();
         c.setCustomId(UUID.randomUUID().toString());
         consumer = kongClient.getConsumerService().createConsumer(c);
-    }
 
-    @AfterClass
-    public static void deleteConsumer() throws Exception {
-        kongClient.getConsumerService().deleteConsumer(consumer.getId());
-    }
-
-    @Test
-    public void test01_addCredentialTest() throws Exception {
         JwtCredential credential = kongClient.getJwtService().addCredentials(consumer.getId(), new JwtCredential());
         assertEquals(consumer.getId(), credential.getConsumerId());
     }
 
-    @Test
-    public void test02_listCredentialsTest() throws Exception {
-        JwtCredentialList list = kongClient.getJwtService().listCredentials(consumer.getId(), null, null);
-        JwtCredential credential = list.getData().get(0);
-        assertEquals(consumer.getId(), credential.getConsumerId());
+    @After
+    public void deleteConsumer() throws Exception {
+        kongClient.getConsumerService().deleteConsumer(consumer.getId());
     }
 
     @Test
-    public void test03_deleteCredentialTest() throws Exception {
+    public void test01_listCredentialsTest() throws Exception {
+        JwtCredentialList list = kongClient.getJwtService().listCredentials(consumer.getId(), null, null);
+        JwtCredential c = list.getData().get(0);
+        assertEquals(consumer.getId(), c.getConsumerId());
+    }
+
+    @Test
+    public void test02_deleteCredentialTest() throws Exception {
         JwtCredentialList list = kongClient.getJwtService().listCredentials(consumer.getId(), null, null);
         JwtCredential credential = list.getData().get(0);
         kongClient.getJwtService().deleteCredentials(consumer.getId(), credential.getId());

--- a/src/test/java/com/github/vaibhavsinha/kong/RetrofitKeyAuthServiceTest.java
+++ b/src/test/java/com/github/vaibhavsinha/kong/RetrofitKeyAuthServiceTest.java
@@ -1,0 +1,79 @@
+package com.github.vaibhavsinha.kong;
+
+import com.github.vaibhavsinha.kong.exception.KongClientException;
+import com.github.vaibhavsinha.kong.model.admin.consumer.Consumer;
+import com.github.vaibhavsinha.kong.model.plugin.authentication.key.KeyAuthCredential;
+import com.github.vaibhavsinha.kong.model.plugin.authentication.key.KeyAuthCredentialList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by dvilela on 11/08/17.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class RetrofitKeyAuthServiceTest extends BaseTest {
+
+    private Consumer consumer;
+
+    @Before
+    public void createConsumer() throws Exception {
+        Consumer c = new Consumer();
+        c.setCustomId(UUID.randomUUID().toString());
+        consumer = kongClient.getConsumerService().createConsumer(c);
+
+        KeyAuthCredential credential = kongClient.getKeyAuthService().addCredentials(consumer.getId(), null);
+        assertEquals(consumer.getId(), credential.getConsumerId());
+        assertNotNull(consumer.getId(), credential.getKey());
+    }
+
+    @After
+    public void deleteConsumer() throws Exception {
+        kongClient.getConsumerService().deleteConsumer(consumer.getId());
+    }
+
+    @Test
+    public void test01_addRepeatedCredentialTest() throws Exception {
+        KeyAuthCredential credential1 = kongClient.getKeyAuthService().addCredentials(consumer.getId(), null);
+        assertEquals(consumer.getId(), credential1.getConsumerId());
+        assertNotNull(consumer.getId(), credential1.getKey());
+
+        try {
+            KeyAuthCredential credential2 = kongClient.getKeyAuthService().addCredentials(consumer.getId(),
+                    credential1.getKey());
+            fail("RetrofitKeyAuthService did not throw");
+        } catch (KongClientException e) {
+            assertEquals(409, e.getCode());
+            assertEquals("Conflict", e.getError());
+        }
+    }
+
+    @Test
+    public void test02_listCredentialsTest() throws Exception {
+        KeyAuthCredentialList list = kongClient.getKeyAuthService().listCredentials(consumer.getId(), null,
+                null);
+        KeyAuthCredential credential = list.getData().get(0);
+        assertEquals(consumer.getId(), credential.getConsumerId());
+    }
+
+    @Test
+    public void test03_deleteCredentialTest() throws Exception {
+        KeyAuthCredentialList list = kongClient.getKeyAuthService().listCredentials(consumer.getId(), null,
+                null);
+        List<KeyAuthCredential> credentials = list.getData();
+        for (KeyAuthCredential credential : credentials) {
+            kongClient.getKeyAuthService().deleteCredential(credential.getConsumerId(), credential.getId());
+        }
+        KeyAuthCredentialList list2 = kongClient.getKeyAuthService().listCredentials(consumer.getId(), null,
+                null);
+        assertEquals(0L, (long) list2.getTotal());
+    }
+
+}


### PR DESCRIPTION
The Services are not handling unexpected status codes. E.g., when we create a credential that already exists, Kong responds with 409 Conflict, but the service ignores the status code and returns null.

The idea is to throw an exception with the status code and HTTP message.